### PR TITLE
pdksync - "setting appropriate owner to be able to create a test matrix"

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,6 @@
 ---
+common:
+  owner: attachmentgenie
 .gitlab-ci.yml:
   delete: true
 .github/workflows/pr_test.yml:


### PR DESCRIPTION
"setting appropriate owner to be able to create a test matrix"
pdk version: `2.2.0` 
