### PR TITLE
pdksync - "moving fixtures to vox module"

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,7 @@
 fixtures:
   forge_modules:
     archive: 'puppet/archive'
-    systemd: 'camptocamp/systemd'
+    systemd: 'puppet/systemd'
     stdlib: 'puppetlabs/stdlib'
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'


### PR DESCRIPTION
"moving fixtures to vox module"
pdk version: `2.2.0` 
