### PR TITLE
pdksync - pdksync_tags/2.2.0-0-g2381db6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
   "tags": [
     "mailhog"
   ],
-  "pdk-version": "2.2.0",
+  "pdk-version": "2.5.0",
   "template-url": "pdk-default#2.2.0",
   "template-ref": "tags/2.2.0-0-g2381db6"
 }


### PR DESCRIPTION
pdksync_tags/2.2.0-0-g2381db6
pdk version: `2.5.0` 
