### PR TITLE
Make mailhog service start on boot

### DIFF
--- a/templates/mailhog.service.erb
+++ b/templates/mailhog.service.erb
@@ -7,3 +7,6 @@ Type=simple
 EnvironmentFile=<%= scope['mailhog::config_file'] %>
 ExecStart=<%= scope['mailhog::install_dir'] %>/mailhog $MAILHOG_OPTS > /dev/null 2>&1
 ExecStop=<%= scope['mailhog::install_dir'] %>/mailhog > /dev/null 2>&1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since the service is enabled in the service.pp and a service can not be enabled when it is not "wantedBy" anything we are attaching to multi-user.target here.