### PR TITLE
add Ubuntu-22.04 as supported OS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     }
   ],


### PR DESCRIPTION
Hi,

I checked the code, it looks working with Ubuntu 22.04.
And a coworker tested it on Ubuntu-22.04, it looks ok.

This adding Ubuntu-22.04 looks as simple as adding it to metadata.json.